### PR TITLE
[UWP] Added keyboard shortcuts for saving popups

### DIFF
--- a/PowerPlannerUWP/Helpers/KeyPressedHelpers.cs
+++ b/PowerPlannerUWP/Helpers/KeyPressedHelpers.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.System;
+using Windows.UI.Core;
+
+namespace PowerPlannerUWP.Helpers
+{
+    static class KeyPressedHelpers
+    {
+        // From: https://docs.microsoft.com/en-us/windows/uwp/design/input/keyboard-events#shortcut-keys-example
+        /// <summary>
+        /// Is the "Control" key pressed (held down)?
+        /// </summary>
+        /// <returns>True if Ctrl key is held down</returns>
+        public static bool IsCtrlKeyPressed()
+        {
+            var ctrlState = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Control);
+            return (ctrlState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
+        }
+    }
+}

--- a/PowerPlannerUWP/Helpers/KeyPressedHelpers.cs
+++ b/PowerPlannerUWP/Helpers/KeyPressedHelpers.cs
@@ -20,5 +20,14 @@ namespace PowerPlannerUWP.Helpers
             var ctrlState = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Control);
             return (ctrlState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
         }
+        
+        /// Is the "Shift" key pressed (held down)?
+        /// </summary>
+        /// <returns>True if Shift key is held down</returns>
+        public static bool IsShiftKeyPressed()
+        {
+            var shiftState = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Shift);
+            return (shiftState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
+        }
     }
 }

--- a/PowerPlannerUWP/PowerPlannerUWP.csproj
+++ b/PowerPlannerUWP/PowerPlannerUWP.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Extensions\UWPTelemetryExtension.cs" />
     <Compile Include="Extensions\UWPTilesExtension.cs" />
     <Compile Include="Helpers\DataPackageHelpers.cs" />
+    <Compile Include="Helpers\KeyPressedHelpers.cs" />
     <Compile Include="Helpers\QueryStringHelper.cs" />
     <Compile Include="Helpers\UWPExceptionHelper.cs" />
     <Compile Include="Helpers\UWPNotificationsHelper.cs" />

--- a/PowerPlannerUWP/Views/AddTaskOrEventView.xaml
+++ b/PowerPlannerUWP/Views/AddTaskOrEventView.xaml
@@ -10,7 +10,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:interfaces="using:InterfacesUWP"
     mc:Ignorable="d"
-    xmlns:localControls="using:PowerPlannerUWP.Controls">
+    xmlns:localControls="using:PowerPlannerUWP.Controls"
+    KeyUp="Popup_KeyUp">
 
     <views:PopupViewHostGeneric.PrimaryCommands>
 

--- a/PowerPlannerUWP/Views/AddTaskOrEventView.xaml.cs
+++ b/PowerPlannerUWP/Views/AddTaskOrEventView.xaml.cs
@@ -25,6 +25,8 @@ using PowerPlannerAppDataLibrary.Extensions;
 using PowerPlannerAppDataLibrary;
 using PowerPlannerAppDataLibrary.Helpers;
 using PowerPlannerUWP.Controls;
+using Windows.UI.Core;
+using Windows.System;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -183,6 +185,26 @@ namespace PowerPlannerUWP.Views
         private async void EditImages_RequestedAddImage(object sender, EventArgs e)
         {
             await ViewModel.AddNewImageAttachmentAsync();
+        }
+
+        // From: https://docs.microsoft.com/en-us/windows/uwp/design/input/keyboard-events#shortcut-keys-example
+        private static bool IsCtrlKeyPressed()
+        {
+            var ctrlState = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Control);
+            return (ctrlState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
+        }
+
+        private void Popup_KeyUp(object sender, KeyRoutedEventArgs e)
+        {
+            if (IsCtrlKeyPressed())
+            {
+                // Ctrl+Enter or Ctrl+S will save the popup
+                if (e.Key == VirtualKey.Enter || e.Key == VirtualKey.S)
+                {
+                    e.Handled = true;
+                    Save();
+                }
+            }
         }
     }
 }

--- a/PowerPlannerUWP/Views/AddTaskOrEventView.xaml.cs
+++ b/PowerPlannerUWP/Views/AddTaskOrEventView.xaml.cs
@@ -27,6 +27,7 @@ using PowerPlannerAppDataLibrary.Helpers;
 using PowerPlannerUWP.Controls;
 using Windows.UI.Core;
 using Windows.System;
+using PowerPlannerUWP.Helpers;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -187,16 +188,9 @@ namespace PowerPlannerUWP.Views
             await ViewModel.AddNewImageAttachmentAsync();
         }
 
-        // From: https://docs.microsoft.com/en-us/windows/uwp/design/input/keyboard-events#shortcut-keys-example
-        private static bool IsCtrlKeyPressed()
-        {
-            var ctrlState = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Control);
-            return (ctrlState & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
-        }
-
         private void Popup_KeyUp(object sender, KeyRoutedEventArgs e)
         {
-            if (IsCtrlKeyPressed())
+            if (KeyPressedHelpers.IsCtrlKeyPressed())
             {
                 // Ctrl+Enter or Ctrl+S will save the popup
                 if (e.Key == VirtualKey.Enter || e.Key == VirtualKey.S)

--- a/PowerPlannerUWP/Views/EditClassDetailsView.xaml
+++ b/PowerPlannerUWP/Views/EditClassDetailsView.xaml
@@ -8,7 +8,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="CLASS DETAILS">
+    Title="CLASS DETAILS"
+    KeyUp="Popup_KeyUp">
 
     <views:PopupViewHostGeneric.PrimaryCommands>
 

--- a/PowerPlannerUWP/Views/EditClassDetailsView.xaml.cs
+++ b/PowerPlannerUWP/Views/EditClassDetailsView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen.Class;
+using PowerPlannerUWP.Helpers;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -6,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -37,6 +39,19 @@ namespace PowerPlannerUWP.Views
         private void ButtonSave_Click(object sender, RoutedEventArgs e)
         {
             ViewModel.Save();
+        }
+
+        private void Popup_KeyUp(object sender, KeyRoutedEventArgs e)
+        {
+            if (KeyPressedHelpers.IsCtrlKeyPressed())
+            {
+                // Ctrl+Enter or Ctrl+S will save the popup
+                if (e.Key == VirtualKey.Enter || e.Key == VirtualKey.S)
+                {
+                    e.Handled = true;
+                    ViewModel.Save();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Added keyboard shortcuts `Ctrl+S` and `Ctrl+Enter` to save AddTaskOrEventView and EditClassDetails popups regardless of active UI element.
- Added KeyPressedHelper class to easily get if `Ctrl` or `Shift` keys are pressed.