### PR TITLE
Grade scale fix

### DIFF
--- a/PowerPlannerAppDataLibrary/DataLayer/AccountDataItem.cs
+++ b/PowerPlannerAppDataLibrary/DataLayer/AccountDataItem.cs
@@ -447,7 +447,7 @@ namespace PowerPlannerAppDataLibrary.DataLayer
         {
             get
             {
-                if (_defaultGradeScale == null)
+                if (_defaultGradeScale == null || _defaultGradeScale.Length == 0)
                 {
                     _defaultGradeScale = GradeScale.GenerateDefaultScaleWithoutLetters();
                 }

--- a/PowerPlannerAppDataLibrary/ViewModels/MainWindow/Settings/Grades/GradeScaleEditorComponent.cs
+++ b/PowerPlannerAppDataLibrary/ViewModels/MainWindow/Settings/Grades/GradeScaleEditorComponent.cs
@@ -254,6 +254,12 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow.Settings.Grades
 
         private bool AreScalesValid()
         {
+            // Require at least one grade scale
+            if (GradeScales.Count == 0)
+            {
+                return false;
+            }
+
             if (GradeScales.Any(i => i.StartingGrade == null || i.GPA == null))
             {
                 return false;


### PR DESCRIPTION
Handle if user deleted all grade scales from default grades (which makes the grades page unfunctional), and also prevent saving empty grade scale going forward.