### PR TITLE
Enable full AOT

### DIFF
--- a/PowerPlannerAndroid/PowerPlannerAndroid.csproj
+++ b/PowerPlannerAndroid/PowerPlannerAndroid.csproj
@@ -9,6 +9,10 @@
 	<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+	<AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+	<EnableLLVM>true</EnableLLVM>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="App\Secrets.template.cs" />
   </ItemGroup>


### PR DESCRIPTION
Faster launch time for only 8MB of package size (31 MB vs 22 MB). The profiled AOT is still too slow, need full AOT