### PR TITLE
Show go to today based on width, and confirmation checkboxes on deleting

### DIFF
--- a/PowerPlannerAppDataLibrary/App/PowerPlannerApp.cs
+++ b/PowerPlannerAppDataLibrary/App/PowerPlannerApp.cs
@@ -5,6 +5,7 @@ using PowerPlannerAppDataLibrary.Extensions;
 using PowerPlannerAppDataLibrary.SyncLayer;
 using PowerPlannerAppDataLibrary.ViewItems;
 using PowerPlannerAppDataLibrary.ViewLists;
+using PowerPlannerAppDataLibrary.ViewModels.Controls;
 using PowerPlannerAppDataLibrary.ViewModels.MainWindow;
 using PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen;
 using PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen.ImageAttachments;
@@ -535,8 +536,13 @@ namespace PowerPlannerAppDataLibrary.App
             }
         }
 
-        public static async Task<bool> ConfirmDeleteAsync(string message = null, string title = null)
+        public static async Task<bool> ConfirmDeleteAsync(string message = null, string title = null, bool useConfirmationCheckbox = false)
         {
+            if (useConfirmationCheckbox)
+            {
+                return await ConfirmDeleteViewModel.ShowForResultAsync(message ?? PowerPlannerResources.GetString("String_ConfirmDeleteItemMessage"), title ?? PowerPlannerResources.GetString("String_ConfirmDeleteItemHeader"));
+            }
+
             return await new PortableMessageDialog(message ?? PowerPlannerResources.GetString("String_ConfirmDeleteItemMessage"), title ?? PowerPlannerResources.GetString("String_ConfirmDeleteItemHeader"), PowerPlannerResources.GetString("MenuItemDelete"), PowerPlannerResources.GetString("MenuItemCancel")).ShowForResultAsync();
         }
     }

--- a/PowerPlannerAppDataLibrary/Components/ClassToolbarComponent.cs
+++ b/PowerPlannerAppDataLibrary/Components/ClassToolbarComponent.cs
@@ -94,7 +94,7 @@ namespace PowerPlannerAppDataLibrary.Components
                         Text = PowerPlannerResources.GetString("String_DeleteClass"),
                         Click = async () =>
                         {
-                            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("String_ConfirmDeleteClassMessage"), PowerPlannerResources.GetString("String_ConfirmDeleteClassHeader")))
+                            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("String_ConfirmDeleteClassMessage"), PowerPlannerResources.GetString("String_ConfirmDeleteClassHeader"), useConfirmationCheckbox: true))
                             {
                                 ViewModel.DeleteClass();
                             }

--- a/PowerPlannerAppDataLibrary/ViewModels/Controls/ConfirmDeleteViewModel.cs
+++ b/PowerPlannerAppDataLibrary/ViewModels/Controls/ConfirmDeleteViewModel.cs
@@ -1,0 +1,134 @@
+﻿using BareMvvm.Core.ViewModels;
+using PowerPlannerAppDataLibrary.App;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Vx.Views;
+
+namespace PowerPlannerAppDataLibrary.ViewModels.Controls
+{
+    public class ConfirmDeleteViewModel : PopupComponentViewModel
+    {
+        private readonly string _title;
+        private readonly string _message;
+        private readonly string _confirmationCheckBox;
+
+        private TaskCompletionSource<bool> _taskCompletionSource = new TaskCompletionSource<bool>();
+
+        private VxState<bool> _isChecked = new VxState<bool>(false);
+
+        private ConfirmDeleteViewModel(PagedViewModelWithPopups parent, string message, string title, string confirmationCheckBox) : base(parent)
+        {
+            _title = title;
+            _message = message;
+            _confirmationCheckBox = confirmationCheckBox;
+
+            Title = title;
+
+            // Listen for if the popup is dismissed
+            parent.Popups.CollectionChanged += Popups_CollectionChanged;
+        }
+
+        private void Popups_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            var parent = (Parent as PagedViewModelWithPopups);
+
+            // If the popup has been dismissed
+            if (!parent.Popups.Contains(this))
+            {
+                // If we haven't already set the result
+                if (!_taskCompletionSource.Task.IsCompleted)
+                {
+                    // Set it as false
+                    _taskCompletionSource.TrySetResult(false);
+                }
+
+                // Unsubscribe from the popup changes
+                parent.Popups.CollectionChanged -= Popups_CollectionChanged;
+            }
+        }
+
+        protected override View Render()
+        {
+            return new LinearLayout
+            {
+                Children =
+                {
+                    new ScrollView
+                    {
+                        Content = new LinearLayout
+                        {
+                            Margin = new Thickness(Theme.Current.PageMargin + NookInsets.Left, Theme.Current.PageMargin + NookInsets.Top, Theme.Current.PageMargin + NookInsets.Right, Theme.Current.PageMargin),
+                            Children =
+                            {
+                                new TextBlock
+                                {
+                                    Text = _message
+                                }
+                            }
+                        }
+                    }.LinearLayoutWeight(1),
+
+                    new LinearLayout
+                    {
+                        Margin = new Thickness(Theme.Current.PageMargin + NookInsets.Left, Theme.Current.PageMargin, Theme.Current.PageMargin + NookInsets.Right, Theme.Current.PageMargin + NookInsets.Bottom),
+                        Children =
+                        {
+                            new CheckBox
+                            {
+                                IsChecked = VxValue.Create(_isChecked.Value, v => _isChecked.Value = v),
+                                Text = _confirmationCheckBox,
+                                Margin = new Thickness(0, 12, 0, 6)
+                            },
+
+                            new LinearLayout
+                            {
+                                Orientation = Orientation.Horizontal,
+                                Children =
+                                {
+                                    new DestructiveButton
+                                    {
+                                        IsEnabled = _isChecked.Value,
+                                        Text = R.S("MenuItemDelete"),
+                                        Click = OnDelete,
+                                        Margin = new Thickness(0, 0, 6, 0)
+                                    }.LinearLayoutWeight(1),
+
+                                    new Button
+                                    {
+                                        Text = R.S("MenuItemCancel"),
+                                        Click = OnCancel,
+                                        Margin = new Thickness(6, 0, 0, 0)
+                                    }.LinearLayoutWeight(1)
+                                }
+                            }
+
+                        }
+                    }
+                }
+            };
+        }
+
+        private void OnDelete()
+        {
+            _taskCompletionSource.TrySetResult(true);
+            RemoveViewModel();
+        }
+
+        private void OnCancel()
+        {
+            _taskCompletionSource.TrySetResult(false);
+            RemoveViewModel();
+        }
+
+        public static Task<bool> ShowForResultAsync(string message, string title)
+        {
+            var parent = PowerPlannerApp.Current.GetMainWindowViewModel().FinalContent.GetPopupViewModelHost();
+            var viewModel = new ConfirmDeleteViewModel(parent, message, title, R.S("Settings_DeleteAccountPage_Description.Text"));
+            parent.ShowPopup(viewModel);
+
+            return viewModel._taskCompletionSource.Task;
+        }
+    }
+}

--- a/PowerPlannerAppDataLibrary/ViewModels/Controls/ConfirmDeleteViewModel.cs
+++ b/PowerPlannerAppDataLibrary/ViewModels/Controls/ConfirmDeleteViewModel.cs
@@ -70,40 +70,33 @@ namespace PowerPlannerAppDataLibrary.ViewModels.Controls
                         }
                     }.LinearLayoutWeight(1),
 
+                    new CheckBox
+                    {
+                        IsChecked = VxValue.Create(_isChecked.Value, v => _isChecked.Value = v),
+                        Text = _confirmationCheckBox,
+                        Margin = new Thickness(Theme.Current.PageMargin + NookInsets.Left, 12, Theme.Current.PageMargin + NookInsets.Right, 6)
+                    },
+
                     new LinearLayout
                     {
-                        Margin = new Thickness(Theme.Current.PageMargin + NookInsets.Left, Theme.Current.PageMargin, Theme.Current.PageMargin + NookInsets.Right, Theme.Current.PageMargin + NookInsets.Bottom),
+                        Orientation = Orientation.Horizontal,
+                        Margin = new Thickness(Theme.Current.PageMargin + NookInsets.Left, 0, Theme.Current.PageMargin + NookInsets.Right, Theme.Current.PageMargin + NookInsets.Bottom),
                         Children =
                         {
-                            new CheckBox
+                            new DestructiveButton
                             {
-                                IsChecked = VxValue.Create(_isChecked.Value, v => _isChecked.Value = v),
-                                Text = _confirmationCheckBox,
-                                Margin = new Thickness(0, 12, 0, 6)
-                            },
+                                IsEnabled = _isChecked.Value,
+                                Text = R.S("MenuItemDelete"),
+                                Click = OnDelete,
+                                Margin = new Thickness(0, 0, 6, 0)
+                            }.LinearLayoutWeight(1),
 
-                            new LinearLayout
+                            new Button
                             {
-                                Orientation = Orientation.Horizontal,
-                                Children =
-                                {
-                                    new DestructiveButton
-                                    {
-                                        IsEnabled = _isChecked.Value,
-                                        Text = R.S("MenuItemDelete"),
-                                        Click = OnDelete,
-                                        Margin = new Thickness(0, 0, 6, 0)
-                                    }.LinearLayoutWeight(1),
-
-                                    new Button
-                                    {
-                                        Text = R.S("MenuItemCancel"),
-                                        Click = OnCancel,
-                                        Margin = new Thickness(6, 0, 0, 0)
-                                    }.LinearLayoutWeight(1)
-                                }
-                            }
-
+                                Text = R.S("MenuItemCancel"),
+                                Click = OnCancel,
+                                Margin = new Thickness(6, 0, 0, 0)
+                            }.LinearLayoutWeight(1)
                         }
                     }
                 }
@@ -124,7 +117,7 @@ namespace PowerPlannerAppDataLibrary.ViewModels.Controls
 
         public static Task<bool> ShowForResultAsync(string message, string title)
         {
-            var parent = PowerPlannerApp.Current.GetMainWindowViewModel().FinalContent.GetPopupViewModelHost();
+            var parent = PowerPlannerApp.Current.GetMainWindowViewModel();
             var viewModel = new ConfirmDeleteViewModel(parent, message, title, R.S("Settings_DeleteAccountPage_Description.Text"));
             parent.ShowPopup(viewModel);
 

--- a/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Calendar/CalendarViewModel.cs
+++ b/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Calendar/CalendarViewModel.cs
@@ -247,6 +247,13 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen.Calendar
             }
         }
 
+        private bool _showGoToTodayInPrimaryCommands = true;
+        public bool ShowGoToTodayInPrimaryCommands
+        {
+            get => _showGoToTodayInPrimaryCommands;
+            set => SetProperty(ref _showGoToTodayInPrimaryCommands, value, nameof(ShowGoToTodayInPrimaryCommands));
+        }
+
         public enum ViewSizeStates
         {
             /// <summary>
@@ -576,6 +583,8 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen.Calendar
 
             else
                 ViewSizeState = ViewSizeStates.FullSize;
+
+            ShowGoToTodayInPrimaryCommands = Size.Width >= 435;
         }
 
         protected override View Render()
@@ -632,14 +641,13 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen.Calendar
                     Glyph = MaterialDesign.MaterialDesignIcons.Today,
                     Click = GoToToday
                 };
-                if (DisplayState == DisplayStates.FullCalendar)
+                if (ShowGoToTodayInPrimaryCommands)
                 {
-                    // On Full calendar, show it in primary commands
                     toolbar.PrimaryCommands.Add(goToTodayMenuItem);
                 }
                 else
                 {
-                    // On compact/split calendars, show it in secondary commands (without a glyph, since the Show past complete doesn't have a glyph either)
+                    // On narrow views, show it in secondary commands (without a glyph, since the Show past complete doesn't have a glyph either)
                     goToTodayMenuItem.Glyph = null;
                     toolbar.SecondaryCommands.Add(goToTodayMenuItem);
                 }

--- a/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Class/AddClassViewModel.cs
+++ b/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Class/AddClassViewModel.cs
@@ -362,7 +362,7 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen.Class
 
         public async void ConfirmDelete()
         {
-            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("String_ConfirmDeleteClassMessage"), PowerPlannerResources.GetString("String_ConfirmDeleteClassHeader")))
+            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("String_ConfirmDeleteClassMessage"), PowerPlannerResources.GetString("String_ConfirmDeleteClassHeader"), useConfirmationCheckbox: true))
             {
                 Delete();
             }

--- a/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Years/AddSemesterViewModel.cs
+++ b/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Years/AddSemesterViewModel.cs
@@ -455,7 +455,9 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen.Years
 
         public async void ConfirmDelete()
         {
-            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("MessageDeleteSemester_Body"), PowerPlannerResources.GetString("MessageDeleteSemester_Title")))
+            bool useConfirmationCheckbox = SemesterToEdit.Classes.Count > 0;
+
+            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("MessageDeleteSemester_Body"), PowerPlannerResources.GetString("MessageDeleteSemester_Title"), useConfirmationCheckbox))
             {
                 Delete();
             }

--- a/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Years/AddYearViewModel.cs
+++ b/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Years/AddYearViewModel.cs
@@ -192,7 +192,9 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen.Years
 
         public async void ConfirmDelete()
         {
-            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("MessageDeleteYear_Body"), PowerPlannerResources.GetString("MessageDeleteYear_Title")))
+            bool useConfirmationCheckbox = YearToEdit.Semesters.Count > 0;
+
+            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("MessageDeleteYear_Body"), PowerPlannerResources.GetString("MessageDeleteYear_Title"), useConfirmationCheckbox))
             {
                 Delete();
             }

--- a/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Years/YearsViewModel.cs
+++ b/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainScreen/Years/YearsViewModel.cs
@@ -547,7 +547,9 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow.MainScreen.Years
 
         public async void DeleteSemester(ViewItemSemester semester)
         {
-            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("MessageDeleteSemester_Body"), PowerPlannerResources.GetString("MessageDeleteSemester_Title")))
+            bool useConfirmationCheckbox = semester.Classes.Count > 0;
+
+            if (await PowerPlannerApp.ConfirmDeleteAsync(PowerPlannerResources.GetString("MessageDeleteSemester_Body"), PowerPlannerResources.GetString("MessageDeleteSemester_Title"), useConfirmationCheckbox))
             {
                 await MainScreenViewModel.DeleteItem(semester.Identifier);
             }


### PR DESCRIPTION
Display the "Go to today" button on the calendar if the width is big enough.

Add a confirmation checkbox when deleting sizeable items like years, semesters, and classes.