### PR TITLE
Update packages, reliability bug fixes, coalesce page view telemetry

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -65,13 +65,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_ref || github.ref }}
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
           dotnet-quality: 'ga'
@@ -140,7 +140,7 @@ jobs:
           Write-Host "AAB: $destDir\$newName"
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: com.barebonesdev.powerplanner.${{ env.BUILD_VERSION }}.0.aab
           path: artifacts/*.aab
@@ -152,7 +152,7 @@ jobs:
       BUILD_VERSION: ${{ needs.set-version.outputs.build_version }}
     steps:
       - name: Download AAB artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: com.barebonesdev.powerplanner.*.aab
           path: artifacts

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_ref || github.ref }}
           submodules: recursive
@@ -140,7 +140,7 @@ jobs:
           Write-Host "AAB: $destDir\$newName"
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: com.barebonesdev.powerplanner.${{ env.BUILD_VERSION }}.0.aab
           path: artifacts/*.aab
@@ -152,7 +152,7 @@ jobs:
       BUILD_VERSION: ${{ needs.set-version.outputs.build_version }}
     steps:
       - name: Download AAB artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: com.barebonesdev.powerplanner.*.aab
           path: artifacts

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_ref || github.ref }}
           submodules: recursive
@@ -196,7 +196,7 @@ jobs:
           echo "IPA: artifacts/PowerPlanneriOS.${{ env.BUILD_VERSION }}.0.ipa"
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: PowerPlanneriOS.${{ env.BUILD_VERSION }}.0.ipa
           path: artifacts/*.ipa
@@ -212,7 +212,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Download IPA artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: PowerPlanneriOS.*.ipa
           path: artifacts

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_ref || github.ref }}
           submodules: recursive
@@ -66,7 +66,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.202'
 
@@ -196,7 +196,7 @@ jobs:
           echo "IPA: artifacts/PowerPlanneriOS.${{ env.BUILD_VERSION }}.0.ipa"
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: PowerPlanneriOS.${{ env.BUILD_VERSION }}.0.ipa
           path: artifacts/*.ipa
@@ -212,7 +212,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Download IPA artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: PowerPlanneriOS.*.ipa
           path: artifacts

--- a/.github/workflows/build-maccatalyst.yml
+++ b/.github/workflows/build-maccatalyst.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_ref || github.ref }}
           submodules: recursive
@@ -62,7 +62,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.202'
 
@@ -287,7 +287,7 @@ jobs:
           echo "PKG: artifacts/PowerPlannerMac.${{ env.BUILD_VERSION }}.pkg"
 
       - name: Upload PKG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: PowerPlannerMac.${{ env.BUILD_VERSION }}.pkg
           path: artifacts/*.pkg
@@ -303,7 +303,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Download PKG artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: PowerPlannerMac.*.pkg
           path: artifacts

--- a/.github/workflows/build-maccatalyst.yml
+++ b/.github/workflows/build-maccatalyst.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_ref || github.ref }}
           submodules: recursive
@@ -287,7 +287,7 @@ jobs:
           echo "PKG: artifacts/PowerPlannerMac.${{ env.BUILD_VERSION }}.pkg"
 
       - name: Upload PKG artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: PowerPlannerMac.${{ env.BUILD_VERSION }}.pkg
           path: artifacts/*.pkg
@@ -303,7 +303,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Download PKG artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: PowerPlannerMac.*.pkg
           path: artifacts

--- a/.github/workflows/build-maccatalyst.yml
+++ b/.github/workflows/build-maccatalyst.yml
@@ -401,5 +401,5 @@ jobs:
             --skip_screenshots \
             --automatic_release "true" \
             --precheck_include_in_app_purchases false \
-            --platform mac \
+            --platform osx \
             --force

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_ref || github.ref }}
           submodules: recursive
@@ -167,7 +167,7 @@ jobs:
           Expand-Archive -Path "AppxPackages\PowerPlannerUWP.msixupload.zip" -DestinationPath "AppxPackages\Extracted"
 
       - name: Upload AppxPackages artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: AppxPackages_${{ matrix.platform }}
           path: AppxPackages/Extracted/
@@ -180,19 +180,19 @@ jobs:
 
     steps:
       - name: Download AppxPackages x86
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: AppxPackages_x86
           path: AppxPackages/
 
       - name: Download AppxPackages x64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: AppxPackages_x64
           path: AppxPackages/
 
       - name: Download AppxPackages ARM64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: AppxPackages_ARM64
           path: AppxPackages/
@@ -255,7 +255,7 @@ jobs:
           & $signtool.FullName sign /debug /a /v /fd SHA256 /f $certPath /p $env:SIGN_CERT_PASSWORD "PowerPlannerUWP_${{ env.BUILD_VERSION }}.0_x86_x64_ARM64.msixbundle"
 
       - name: Upload test artifact (signed bundle)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: PowerPlannerUWP_${{ env.BUILD_VERSION }}_test
           path: bundles/PowerPlannerUWP_${{ env.BUILD_VERSION }}.0_x86_x64_ARM64.msixbundle
@@ -269,7 +269,7 @@ jobs:
           Compress-Archive -Path "upload/*" -DestinationPath "upload/PowerPlannerUWP_${{ env.BUILD_VERSION }}.0_x86_x64_ARM64.msixupload"
 
       - name: Upload appxupload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: PowerPlannerUWP_${{ env.BUILD_VERSION }}_appxupload
           path: upload/PowerPlannerUWP_${{ env.BUILD_VERSION }}.0_x86_x64_ARM64.msixupload
@@ -310,7 +310,7 @@ jobs:
 
     steps:
       - name: Download msixupload artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: PowerPlannerUWP_${{ env.BUILD_VERSION }}_appxupload
           path: upload/

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -129,12 +129,12 @@ jobs:
         continue-on-error: true
 
       - name: Setup NuGet
-        uses: nuget/setup-nuget@v2
+        uses: nuget/setup-nuget@v3
         with:
           nuget-version: '7.x'
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: NuGet restore
         run: >-

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_ref || github.ref }}
           submodules: recursive
@@ -167,7 +167,7 @@ jobs:
           Expand-Archive -Path "AppxPackages\PowerPlannerUWP.msixupload.zip" -DestinationPath "AppxPackages\Extracted"
 
       - name: Upload AppxPackages artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: AppxPackages_${{ matrix.platform }}
           path: AppxPackages/Extracted/
@@ -180,19 +180,19 @@ jobs:
 
     steps:
       - name: Download AppxPackages x86
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: AppxPackages_x86
           path: AppxPackages/
 
       - name: Download AppxPackages x64
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: AppxPackages_x64
           path: AppxPackages/
 
       - name: Download AppxPackages ARM64
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: AppxPackages_ARM64
           path: AppxPackages/
@@ -255,7 +255,7 @@ jobs:
           & $signtool.FullName sign /debug /a /v /fd SHA256 /f $certPath /p $env:SIGN_CERT_PASSWORD "PowerPlannerUWP_${{ env.BUILD_VERSION }}.0_x86_x64_ARM64.msixbundle"
 
       - name: Upload test artifact (signed bundle)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: PowerPlannerUWP_${{ env.BUILD_VERSION }}_test
           path: bundles/PowerPlannerUWP_${{ env.BUILD_VERSION }}.0_x86_x64_ARM64.msixbundle
@@ -269,7 +269,7 @@ jobs:
           Compress-Archive -Path "upload/*" -DestinationPath "upload/PowerPlannerUWP_${{ env.BUILD_VERSION }}.0_x86_x64_ARM64.msixupload"
 
       - name: Upload appxupload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: PowerPlannerUWP_${{ env.BUILD_VERSION }}_appxupload
           path: upload/PowerPlannerUWP_${{ env.BUILD_VERSION }}.0_x86_x64_ARM64.msixupload
@@ -310,7 +310,7 @@ jobs:
 
     steps:
       - name: Download msixupload artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: PowerPlannerUWP_${{ env.BUILD_VERSION }}_appxupload
           path: upload/

--- a/PowerPlannerAndroid/Extensions/AndroidInAppPurchaseExtension.cs
+++ b/PowerPlannerAndroid/Extensions/AndroidInAppPurchaseExtension.cs
@@ -173,7 +173,7 @@ namespace PowerPlannerAndroid.Extensions
             {
                 var builder = BillingClient.NewBuilder(context.ApplicationContext);
                 builder.SetListener(PurchasesUpdatedListener);
-                builder.EnablePendingPurchases(); // This is required unfortunately
+                builder.EnablePendingPurchases(PendingPurchasesParams.NewBuilder().EnableOneTimeProducts().Build()); // This is required unfortunately
                 _billingClient = builder.Build();
             }
 

--- a/PowerPlannerAndroid/Extensions/DroidTelemetryExtension.cs
+++ b/PowerPlannerAndroid/Extensions/DroidTelemetryExtension.cs
@@ -23,8 +23,7 @@ namespace PowerPlannerAndroid.Extensions
         {
             try
             {
-                var config = new TelemetryConfiguration();
-                config.TelemetryChannel = new InMemoryChannel();
+                var config = TelemetryConfiguration.CreateDefault();
                 config.ConnectionString = Secrets.AppCenterAppSecret;
                 _client = new TelemetryClient(config);
 
@@ -116,19 +115,6 @@ namespace PowerPlannerAndroid.Extensions
             _developerLogs.Add(str);
 
             _client.GetMetric(metricId, dim1Label, dim2Label).TrackValue(metricValue, dim1Value, dim2Value);
-        }
-
-        private string _lastPageName;
-        public override string LastPageName => _lastPageName;
-        public override void TrackPageVisited(string pageName)
-        {
-            try
-            {
-                _lastPageName = pageName;
-
-                _client.TrackPageView(pageName);
-            }
-            catch { }
         }
 
         public override void TrackException(Exception ex, [CallerMemberName] string exceptionName = null, IDictionary<string, string> properties = null)

--- a/PowerPlannerAndroid/Extensions/DroidTelemetryExtension.cs
+++ b/PowerPlannerAndroid/Extensions/DroidTelemetryExtension.cs
@@ -23,7 +23,8 @@ namespace PowerPlannerAndroid.Extensions
         {
             try
             {
-                var config = TelemetryConfiguration.CreateDefault();
+                var config = new TelemetryConfiguration();
+                config.TelemetryChannel = new InMemoryChannel();
                 config.ConnectionString = Secrets.AppCenterAppSecret;
                 _client = new TelemetryClient(config);
 

--- a/PowerPlannerAndroid/PowerPlannerAndroid.csproj
+++ b/PowerPlannerAndroid/PowerPlannerAndroid.csproj
@@ -32,35 +32,32 @@
     <ProjectReference Include="..\PowerPlannerAppDataLibrary\PowerPlanner.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
     <PackageReference Include="StorageEverywhereIncludingiOS" Version="10.0.4" />
     <PackageReference Include="Xam.Plugins.Settings">
       <Version>5.0.0-beta</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Glide" Version="5.0.5.1" />
+    <PackageReference Include="Xamarin.Android.Glide" Version="5.0.7" />
     <PackageReference Include="Xamarin.Android.Google.BillingClient">
-      <Version>6.1.0.2</Version>
+      <Version>9.0.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.PhotoView">
       <Version>2.1.4</Version>
     </PackageReference>
-	<!--Need these two Jvm packages to address .NET issue https://github.com/dotnet/android-libraries/issues/1341-->
-	<PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm" Version="1.10.0.1" ExcludeAssets="all" />
-	<PackageReference Include="Xamarin.AndroidX.DataStore.Preferences.Core.Jvm" Version="1.2.0.1" ExcludeAssets="all" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4">
-      <Version>1.0.0.35</Version>
+      <Version>1.0.0.36</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Build.Download">
       <Version>0.11.4</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Firebase.Messaging">
-      <Version>125.0.1.1</Version>
+      <Version>125.0.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Google.Android.Material">
-      <Version>1.13.0.1</Version>
+      <Version>1.14.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Google.Dagger">
-      <Version>2.57.2.1</Version>
+      <Version>2.59.2.1</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/PowerPlannerAndroid/PowerPlannerAndroid.csproj
+++ b/PowerPlannerAndroid/PowerPlannerAndroid.csproj
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\PowerPlannerAppDataLibrary\PowerPlanner.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" /> <!--Keep on 2.x, 3.x is about 10MB bigger!-->
     <PackageReference Include="StorageEverywhereIncludingiOS" Version="10.0.4" />
     <PackageReference Include="Xam.Plugins.Settings">
       <Version>5.0.0-beta</Version>

--- a/PowerPlannerAppDataLibrary/DataLayer/AccountDataStore.cs
+++ b/PowerPlannerAppDataLibrary/DataLayer/AccountDataStore.cs
@@ -1255,11 +1255,14 @@ namespace PowerPlannerAppDataLibrary.DataLayer
         /// <returns></returns>
         public async Task<string> GetNextImageToUploadAsync()
         {
-            return await System.Threading.Tasks.Task.Run(new Func<string>(GetNextImageToUploadBlocking));
+            using (await Locks.LockDataForReadAsync())
+            {
+                return GetNextImageToUploadBlocking();
+            }
         }
 
         /// <summary>
-        /// Doesn't use data lock
+        /// Caller must establish data lock
         /// </summary>
         /// <returns></returns>
         private string GetNextImageToUploadBlocking()
@@ -1274,14 +1277,14 @@ namespace PowerPlannerAppDataLibrary.DataLayer
 
         public async System.Threading.Tasks.Task MarkImageUploadedAsync(string fileName)
         {
-            await System.Threading.Tasks.Task.Run(delegate
+            using (await Locks.LockDataForWriteAsync())
             {
                 MarkImageUploadedBlocking(fileName);
-            });
+            }
         }
 
         /// <summary>
-        /// Doesn't use data lock
+        /// Caller must establish data lock
         /// </summary>
         /// <param name="fileName"></param>
         private void MarkImageUploadedBlocking(string fileName)

--- a/PowerPlannerAppDataLibrary/DataLayer/AccountDataStore.cs
+++ b/PowerPlannerAppDataLibrary/DataLayer/AccountDataStore.cs
@@ -923,6 +923,16 @@ namespace PowerPlannerAppDataLibrary.DataLayer
                 // On UWP, we were adding duplicates to calendar integration, so we'll reset calendar integration
                 needsAppointmentReset = true;
             }
+            if (version < 8)
+            {
+                // This fixes a VERY OLD bug that I never fixed, introduced around version 5.4.62.0...
+                // GpaType was added to DataItemClass a LONG time ago. However, unlike StartDate/EndDate (v4)
+                // and PassingGrade (v5), it was never backfilled, so class rows created before the column
+                // existed still hold NULL in this non-nullable column. This throws:
+                //   "The data is NULL at ordinal N. This method can't be called on NULL values."
+                // Only touch NULL rows so we don't clobber valid PassFail values on newer databases.
+                _db.Database.ExecuteSqlRaw("update DataItemClass set GpaType = {0} where GpaType is NULL", (int)GpaType.Standard);
+            }
             if (version < DataInfo.LATEST_VERSION)
             {
                 dataInfo.Version = DataInfo.LATEST_VERSION;
@@ -1099,7 +1109,7 @@ namespace PowerPlannerAppDataLibrary.DataLayer
 
         public class DataInfo
         {
-            public const int LATEST_VERSION = 7;
+            public const int LATEST_VERSION = 8;
 
             [Key]
             public short Key { get; set; } = 1;

--- a/PowerPlannerAppDataLibrary/Extensions/TelemetryExtension.cs
+++ b/PowerPlannerAppDataLibrary/Extensions/TelemetryExtension.cs
@@ -68,15 +68,75 @@ namespace PowerPlannerAppDataLibrary.Extensions
         public abstract string GetDeveloperLogs();
 
         private string _lastPageName;
+        private object _pageViewLock = new object();
+        private TelemetryPageViewBundler _pageViewBundler;
         public virtual string LastPageName => _lastPageName;
         public virtual void TrackPageVisited(string pageName)
         {
-            _lastPageName = pageName;
+            try
+            {
+                _lastPageName = pageName;
+
+                DateTime utcTimeVisited = DateTime.UtcNow;
+                string userId = UserId;
+
+                lock (_pageViewLock)
+                {
+                    if (_pageViewBundler == null)
+                    {
+                        _pageViewBundler = new TelemetryPageViewBundler(userId);
+                    }
+
+                    // If able to add the page to the bundler
+                    if (_pageViewBundler.TryAddPage(userId, pageName, utcTimeVisited))
+                    {
+                        return;
+                    }
+
+                    // Otherwise, need to log bundler and create new
+                    FinishPageViewBundler();
+
+                    // And then add to new one
+                    _pageViewBundler = new TelemetryPageViewBundler(userId);
+                    _pageViewBundler.TryAddPage(userId, pageName, utcTimeVisited);
+                }
+            }
+            catch (Exception ex)
+            {
+                TrackException(ex);
+            }
+        }
+
+        public virtual void LeavingApp()
+        {
+            try
+            {
+                lock (_pageViewLock)
+                {
+                    if (_pageViewBundler != null)
+                    {
+                        FinishPageViewBundler();
+                    }
+                }
+            }
+            catch (Exception ex) { TrackException(ex); }
+        }
+
+        public virtual void ReturnedToApp()
+        {
+            // I don't do anything here. I could theoretically log the page view again (since I ended the page view last time they left the app), but that could lead to tons of events if they're constantly switching back and forth between Power Planner and another app. I think it'd be better if we just log the next page view.
         }
 
         public virtual void SuspendingApp()
         {
 
+        }
+
+        private void FinishPageViewBundler()
+        {
+            TrackEvent("PageViews", _pageViewBundler.GenerateProperties());
+
+            _pageViewBundler = null;
         }
 
         public virtual void UpdateCurrentUser(AccountDataItem account)

--- a/PowerPlannerAppDataLibrary/Extensions/TelemetryExtension.cs
+++ b/PowerPlannerAppDataLibrary/Extensions/TelemetryExtension.cs
@@ -129,7 +129,17 @@ namespace PowerPlannerAppDataLibrary.Extensions
 
         public virtual void SuspendingApp()
         {
-
+            try
+            {
+                lock (_pageViewLock)
+                {
+                    if (_pageViewBundler != null)
+                    {
+                        FinishPageViewBundler();
+                    }
+                }
+            }
+            catch (Exception ex) { TrackException(ex); }
         }
 
         private void FinishPageViewBundler()

--- a/PowerPlannerAppDataLibrary/Helpers/TelemetryPageViewBundler.cs
+++ b/PowerPlannerAppDataLibrary/Helpers/TelemetryPageViewBundler.cs
@@ -7,18 +7,13 @@ namespace PowerPlannerAppDataLibrary.Helpers
 {
     public class TelemetryPageViewBundler
     {
-        /// <summary>
-        /// Event properties will include AccountId, Date, and then 18 spots more left for page properties
-        /// </summary>
-        private const int MaxPageProperties = 18;
-
-        private const int MaxPropertyValueLength = 125;
+        private const int MaxPropertyValueLength = 8000; // Up to 8192 technically
 
         public DateTime UtcDate { get; private set; } = DateTime.UtcNow.Date;
 
         public string UserId { get; private set; }
 
-        private List<string> _pageProperties = new List<string>();
+        private string _pageEntries;
 
         public TelemetryPageViewBundler(string userId)
         {
@@ -42,24 +37,17 @@ namespace PowerPlannerAppDataLibrary.Helpers
             string pageEntry = FormatPageEntry(pageName, utcTimeVisited);
 
             // If very first
-            if (_pageProperties.Count == 0)
+            if (_pageEntries == null)
             {
-                _pageProperties.Add(pageEntry);
+                _pageEntries = pageEntry;
                 return true;
             }
 
             // If current has space
-            if (HasSpace(_pageProperties.Last(), pageEntry))
+            if (HasSpace(_pageEntries, pageEntry))
             {
-                _pageProperties[_pageProperties.Count - 1] = _pageProperties.Last() + ";" + pageEntry;
+                _pageEntries += ";" + pageEntry;
                 return true;
-            }
-
-            // Otherwise if we're under property limit
-            if (_pageProperties.Count <= MaxPageProperties)
-            {
-                // Add new
-                _pageProperties.Add(pageEntry);
             }
 
             // Otherwise we're full
@@ -74,10 +62,9 @@ namespace PowerPlannerAppDataLibrary.Helpers
                 { "AccountId", UserId } // We have to add AccountId, since if it changed, the AccountId automatically logged would be different
             };
 
-            // Entries0 - Entries17
-            for (int i = 0; i < _pageProperties.Count; i++)
+            if (_pageEntries != null)
             {
-                answer.Add($"Entries{i}", _pageProperties[i]);
+                answer.Add("Entries", _pageEntries);
             }
 
             return answer;

--- a/PowerPlannerAppDataLibrary/PowerPlanner.csproj
+++ b/PowerPlannerAppDataLibrary/PowerPlanner.csproj
@@ -25,16 +25,16 @@
     <None Include="App\Secrets.template.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="PowerPlannerAppAuthLibrary" Version="1.260219.4" />
     <PackageReference Include="StorageEverywhereIncludingiOS" Version="10.0.4" />
-    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
-    <PackageReference Include="TimeZoneNames" Version="6.0.0" />
+    <PackageReference Include="TimeZoneConverter" Version="7.2.0" />
+    <PackageReference Include="TimeZoneNames" Version="7.0.0" />
     <PackageReference Include="Xam.Plugins.Settings" Version="5.0.0-beta" />
-    <PackageReference Include="XliffCompiler" Version="1.0.12">
+    <PackageReference Include="XliffCompiler" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>

--- a/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainWindowViewModel.cs
+++ b/PowerPlannerAppDataLibrary/ViewModels/MainWindow/MainWindowViewModel.cs
@@ -438,6 +438,7 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow
         public void HandleBeingLeft()
         {
             _timeLeftAt = DateTime.Now;
+            TelemetryExtension.Current?.LeavingApp();
         }
 
         public async Task HandleBeingReturnedTo()
@@ -485,6 +486,8 @@ namespace PowerPlannerAppDataLibrary.ViewModels.MainWindow
             {
                 TelemetryExtension.Current?.TrackException(ex);
             }
+
+            TelemetryExtension.Current?.ReturnedToApp();
         }
 
         public MainScreenViewModel GetMainScreenViewModel()

--- a/PowerPlannerUWP/App.xaml.cs
+++ b/PowerPlannerUWP/App.xaml.cs
@@ -159,6 +159,11 @@ namespace PowerPlannerUWP
         private void App_UnhandledException(object sender, Windows.UI.Xaml.UnhandledExceptionEventArgs e)
         {
             string currPage = TelemetryExtension.Current?.LastPageName;
+            try
+            {
+                TelemetryExtension.Current?.LeavingApp();
+            }
+            catch { }
 
             TelemetryExtension.Current?.TrackException(e.Exception, properties: currPage != null ? new Dictionary<string, string>
             {

--- a/PowerPlannerUWP/Extensions/UWPTelemetryExtension.cs
+++ b/PowerPlannerUWP/Extensions/UWPTelemetryExtension.cs
@@ -23,7 +23,8 @@ namespace PowerPlannerUWP.Extensions
         {
             try
             {
-                var config = TelemetryConfiguration.CreateDefault();
+                var config = new TelemetryConfiguration();
+                config.TelemetryChannel = new InMemoryChannel();
                 config.ConnectionString = Secrets.AppCenterAppSecret;
                 _client = new TelemetryClient(config);
 

--- a/PowerPlannerUWP/Extensions/UWPTelemetryExtension.cs
+++ b/PowerPlannerUWP/Extensions/UWPTelemetryExtension.cs
@@ -23,8 +23,7 @@ namespace PowerPlannerUWP.Extensions
         {
             try
             {
-                var config = new TelemetryConfiguration();
-                config.TelemetryChannel = new InMemoryChannel();
+                var config = TelemetryConfiguration.CreateDefault();
                 config.ConnectionString = Secrets.AppCenterAppSecret;
                 _client = new TelemetryClient(config);
 
@@ -74,19 +73,6 @@ namespace PowerPlannerUWP.Extensions
             _developerLogs.Add(str);
 
             _client.GetMetric(metricId, dim1Label, dim2Label).TrackValue(metricValue, dim1Value, dim2Value);
-        }
-
-        private string _lastPageName;
-        public override string LastPageName => _lastPageName;
-        public override void TrackPageVisited(string pageName)
-        {
-            try
-            {
-                _lastPageName = pageName;
-
-                _client.TrackPageView(pageName);
-            }
-            catch { }
         }
 
         public override void TrackException(Exception ex, [CallerMemberName] string exceptionName = null, IDictionary<string, string> properties = null)

--- a/PowerPlannerUWP/PowerPlannerUWP.csproj
+++ b/PowerPlannerUWP/PowerPlannerUWP.csproj
@@ -26,7 +26,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.ApplicationInsights">
-			<Version>2.23.0</Version>
+			<Version>3.1.2</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
 			<Version>7.1.3</Version>

--- a/PowerPlannerUWP/PowerPlannerUWP.csproj
+++ b/PowerPlannerUWP/PowerPlannerUWP.csproj
@@ -37,6 +37,7 @@
 		<PackageReference Include="StorageEverywhereIncludingiOS">
 			<Version>10.0.4</Version>
 		</PackageReference>
+		<PackageReference Include="System.Drawing.Common" Version="4.7.3" /> <!--Only added since MS Toolkit UWP Notifs depends on >=4.7.0, but 4.7.0 has a security vulnerability-->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/PowerPlannerUWP/PowerPlannerUWP.csproj
+++ b/PowerPlannerUWP/PowerPlannerUWP.csproj
@@ -25,8 +25,8 @@
 		<TrimMode>partial</TrimMode>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.ApplicationInsights">
-			<Version>3.1.2</Version>
+		<PackageReference Include="Microsoft.ApplicationInsights"> <!--Keep on 2.x, 3.x is about 10MB bigger!-->
+			<Version>2.23.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
 			<Version>7.1.3</Version>

--- a/PowerPlanneriOS/Extensions/iOSTelemetryExtension.cs
+++ b/PowerPlanneriOS/Extensions/iOSTelemetryExtension.cs
@@ -21,8 +21,7 @@ namespace PowerPlanneriOS.Extensions
         {
             try
             {
-                var config = new TelemetryConfiguration();
-                config.TelemetryChannel = new InMemoryChannel();
+                var config = TelemetryConfiguration.CreateDefault();
                 config.ConnectionString = Secrets.AppCenterAppSecret;
                 _client = new TelemetryClient(config);
 
@@ -101,19 +100,6 @@ namespace PowerPlanneriOS.Extensions
             _developerLogs.Add(str);
 
             _client.GetMetric(metricId, dim1Label, dim2Label).TrackValue(metricValue, dim1Value, dim2Value);
-        }
-
-        private string _lastPageName;
-        public override string LastPageName => _lastPageName;
-        public override void TrackPageVisited(string pageName)
-        {
-            try
-            {
-                _lastPageName = pageName;
-
-                _client.TrackPageView(pageName);
-            }
-            catch { }
         }
 
         public override void TrackException(Exception ex, [CallerMemberName] string exceptionName = null, IDictionary<string, string> properties = null)

--- a/PowerPlanneriOS/Extensions/iOSTelemetryExtension.cs
+++ b/PowerPlanneriOS/Extensions/iOSTelemetryExtension.cs
@@ -21,7 +21,8 @@ namespace PowerPlanneriOS.Extensions
         {
             try
             {
-                var config = TelemetryConfiguration.CreateDefault();
+                var config = new TelemetryConfiguration();
+                config.TelemetryChannel = new InMemoryChannel();
                 config.ConnectionString = Secrets.AppCenterAppSecret;
                 _client = new TelemetryClient(config);
 

--- a/PowerPlanneriOS/PowerPlanneriOS.csproj
+++ b/PowerPlanneriOS/PowerPlanneriOS.csproj
@@ -59,7 +59,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
     <PackageReference Include="StorageEverywhereIncludingiOS" Version="10.0.4" />
     <PackageReference Include="Xam.Plugins.Settings" Version="5.0.0-beta">
     </PackageReference>

--- a/PowerPlanneriOS/PowerPlanneriOS.csproj
+++ b/PowerPlanneriOS/PowerPlanneriOS.csproj
@@ -59,7 +59,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" /> <!--Keep on 2.x, 3.x is about 10MB bigger!-->
     <PackageReference Include="StorageEverywhereIncludingiOS" Version="10.0.4" />
     <PackageReference Include="Xam.Plugins.Settings" Version="5.0.0-beta">
     </PackageReference>

--- a/PowerPlanneriOS/SceneDelegate.cs
+++ b/PowerPlanneriOS/SceneDelegate.cs
@@ -1,5 +1,9 @@
 #if MACCATALYST
 using Foundation;
+using PowerPlannerAppDataLibrary.App;
+using PowerPlannerAppDataLibrary.Extensions;
+using PowerPlannerAppDataLibrary.Windows;
+using System.Linq;
 using UIKit;
 
 namespace PowerPlanneriOS
@@ -30,10 +34,38 @@ namespace PowerPlanneriOS
         public void DidDisconnect(UIScene scene) { }
 
         [Export("sceneDidBecomeActive:")]
-        public void DidBecomeActive(UIScene scene) { }
+        public void DidBecomeActive(UIScene scene)
+        {
+            try
+            {
+                foreach (var window in PowerPlannerApp.Current.Windows.OfType<MainAppWindow>())
+                {
+                    var dontWait = window.GetViewModel().HandleBeingReturnedTo();
+                }
+            }
+
+            catch { }
+        }
 
         [Export("sceneWillResignActive:")]
-        public void WillResignActive(UIScene scene) { }
+        public void WillResignActive(UIScene scene)
+        {
+            try
+            {
+                foreach (var window in PowerPlannerApp.Current.Windows.OfType<MainAppWindow>())
+                {
+                    window.GetViewModel().HandleBeingLeft();
+                }
+            }
+
+            catch { }
+
+            try
+            {
+                TelemetryExtension.Current?.SuspendingApp();
+            }
+            catch { }
+        }
 
         [Export("sceneWillEnterForeground:")]
         public void WillEnterForeground(UIScene scene) { }

--- a/Vx.Droid/Vx.Droid.csproj
+++ b/Vx.Droid/Vx.Droid.csproj
@@ -9,13 +9,13 @@
     <ProjectReference Include="..\Vx\Vx.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Android.Glide" Version="5.0.5.1" />
+    <PackageReference Include="Xamarin.Android.Glide" Version="5.0.7" />
     <PackageReference Include="Xamarin.Android.PhotoView" Version="2.1.4" />
     <PackageReference Include="Xamarin.Android.ViewPump">
       <Version>2.0.3.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.2" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.13.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.3" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.14.0.1" />
     <PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
   </ItemGroup>
 </Project>

--- a/Vx.iOS/Views/UIButtonContentView.cs
+++ b/Vx.iOS/Views/UIButtonContentView.cs
@@ -20,7 +20,10 @@ namespace Vx.iOS.Views
         {
             // The default UIButton init produces a UIButtonType.Custom button (no system styling).
             // Explicitly ensure no configuration-based background is applied.
-            Configuration = null;
+            if (OperatingSystem.IsIOSVersionAtLeast(15))
+            {
+                Configuration = null;
+            }
 
             _contentView = new UIContentView
             {

--- a/Vx/Vx.csproj
+++ b/Vx/Vx.csproj
@@ -10,7 +10,7 @@
     <SuppressPseudoWarning Condition="'$(Configuration)' == 'Debug'">true</SuppressPseudoWarning>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="XliffCompiler" Version="1.0.12">
+    <PackageReference Include="XliffCompiler" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Updating NuGet packages
- Refactoring page view telemetry events into single custom `PageViews` event (with an `Entries` property)
- Fix a very old database migration bug from version 5.4.62.0 that I never fixed
- Update CI actions to latest versions
- Fix iOS button API being called on iOS 14
- Fix potential upload image deadlock bug
- Report `PC` device type when on Mac (OS will still be `iPadOS`)
- Hopefully fix the "Publish Mac" CI step (setting correct OS type)