### PR TITLE
Skip scheduling iOS notifs if perms are denied

### DIFF
--- a/PowerPlannerAndroid/Extensions/AndroidRemindersExtension.cs
+++ b/PowerPlannerAndroid/Extensions/AndroidRemindersExtension.cs
@@ -116,6 +116,11 @@ namespace PowerPlannerAndroid.Extensions
 
         public static async Task UpdateAndScheduleNotifications(Context context, AccountDataItem account, bool fromForeground)
         {
+            if (!NotificationManagerCompat.From(context).AreNotificationsEnabled())
+            {
+                return;
+            }
+
             DateTime now = DateTime.Now;
             var agendaItems = await AndroidRemindersExtension.GetAgendaViewItemsGroup(account, now.Date);
             var notificationManager = (NotificationManager)context.GetSystemService(Context.NotificationService);

--- a/PowerPlannerAndroid/Extensions/AndroidRemindersExtension.cs
+++ b/PowerPlannerAndroid/Extensions/AndroidRemindersExtension.cs
@@ -116,11 +116,6 @@ namespace PowerPlannerAndroid.Extensions
 
         public static async Task UpdateAndScheduleNotifications(Context context, AccountDataItem account, bool fromForeground)
         {
-            if (!NotificationManagerCompat.From(context).AreNotificationsEnabled())
-            {
-                return;
-            }
-
             DateTime now = DateTime.Now;
             var agendaItems = await AndroidRemindersExtension.GetAgendaViewItemsGroup(account, now.Date);
             var notificationManager = (NotificationManager)context.GetSystemService(Context.NotificationService);

--- a/PowerPlanneriOS/Extensions/IOSRemindersExtension.cs
+++ b/PowerPlanneriOS/Extensions/IOSRemindersExtension.cs
@@ -68,11 +68,23 @@ namespace PowerPlanneriOS.Extensions
             }
         }
 
+        private async Task<bool> IsAuthorizedAsync()
+        {
+            var settings = await _notificationCenter.GetNotificationSettingsAsync();
+            return settings.AuthorizationStatus == UNAuthorizationStatus.Authorized
+                || settings.AuthorizationStatus == UNAuthorizationStatus.Provisional;
+        }
+
         protected override async Task ActuallyClearReminders(Guid localAccountId)
         {
             // This gets called upon account being deleted
             try
             {
+                if (!await IsAuthorizedAsync())
+                {
+                    return;
+                }
+
                 await Task.Run(async delegate
                 {
                     await RemoveAllNotificationsAsync(localAccountId);
@@ -90,6 +102,11 @@ namespace PowerPlanneriOS.Extensions
             // This gets called upon opening/returning to app/logging in
             try
             {
+                if (!await IsAuthorizedAsync())
+                {
+                    return;
+                }
+
                 await Task.Run(async delegate
                 {
                     await RemoveAllCurrentNotificationsAsync(localAccountId);
@@ -112,9 +129,7 @@ namespace PowerPlanneriOS.Extensions
                 }
 
                 // If user denied notification permission, skip all the work
-                var settings = await _notificationCenter.GetNotificationSettingsAsync();
-                if (settings.AuthorizationStatus != UNAuthorizationStatus.Authorized &&
-                    settings.AuthorizationStatus != UNAuthorizationStatus.Provisional)
+                if (!await IsAuthorizedAsync())
                 {
                     return;
                 }

--- a/PowerPlanneriOS/Extensions/IOSRemindersExtension.cs
+++ b/PowerPlanneriOS/Extensions/IOSRemindersExtension.cs
@@ -111,6 +111,14 @@ namespace PowerPlanneriOS.Extensions
                     return;
                 }
 
+                // If user denied notification permission, skip all the work
+                var settings = await _notificationCenter.GetNotificationSettingsAsync();
+                if (settings.AuthorizationStatus != UNAuthorizationStatus.Authorized &&
+                    settings.AuthorizationStatus != UNAuthorizationStatus.Provisional)
+                {
+                    return;
+                }
+
                 await Task.Run(async delegate
                 {
                     // This gets called whenever changes are made in the account's data.


### PR DESCRIPTION
Mac potentially throws exceptions if trying to send notifications when disabled