### PR TITLE
Attempt Mac x64 fix

### DIFF
--- a/.github/workflows/build-maccatalyst.yml
+++ b/.github/workflows/build-maccatalyst.yml
@@ -200,10 +200,10 @@ jobs:
           publish_arch_args=""
           case "$target_arch" in
             x86_64)
-              publish_arch_args="-p:RuntimeIdentifier=maccatalyst-x64 -p:RuntimeIdentifiers=maccatalyst-x64"
+              publish_arch_args="-p:RuntimeIdentifier=maccatalyst-x64"
               ;;
             arm64)
-              publish_arch_args="-p:RuntimeIdentifier=maccatalyst-arm64 -p:RuntimeIdentifiers=maccatalyst-arm64"
+              publish_arch_args="-p:RuntimeIdentifier=maccatalyst-arm64"
               ;;
             universal)
               ;;

--- a/.github/workflows/build-maccatalyst.yml
+++ b/.github/workflows/build-maccatalyst.yml
@@ -190,9 +190,6 @@ jobs:
           -p:CodesignProvision="${{ vars.MAC_APP_PROVISIONING_PROFILE_NAME }}"
           -p:CodesignKey="Apple Distribution: BareBones Dev%2c LLC (A9B367L69G)"
           ${{ vars.ADDITIONAL_BUILD_ARGUMENTS }}
-          -p:CodesignProvision="${{ vars.MAC_APP_PROVISIONING_PROFILE_NAME }}"
-          -p:CodesignKey="Apple Distribution: BareBones Dev%2c LLC (A9B367L69G)"
-          ${{ vars.ADDITIONAL_BUILD_ARGUMENTS }}
 
       - name: Fix widget signature and create signed PKG
         # dotnet re-signs embedded extensions without application-identifier, and the universal

--- a/.github/workflows/build-maccatalyst.yml
+++ b/.github/workflows/build-maccatalyst.yml
@@ -19,6 +19,15 @@ on:
         description: 'Branch, tag, or commit SHA to build'
         required: false
         default: 'main'
+      target_arch:
+        description: 'Mac Catalyst target architecture(s)'
+        required: false
+        default: 'universal'
+        type: choice
+        options:
+          - universal
+          - x86_64
+          - arm64
       whats_new:
         description: 'Release notes (Whats New) for the Mac App Store submission'
         required: false
@@ -179,17 +188,51 @@ jobs:
       - name: Build XliffCompiler (dotnet build PowerPlanner)
         run: dotnet build PowerPlannerAppDataLibrary/PowerPlanner.csproj -c Release
 
+      - name: Resolve Mac Catalyst publish target
+        id: maccatalyst_target
+        shell: bash
+        run: |
+          target_arch="universal"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.target_arch }}" ]; then
+            target_arch="${{ github.event.inputs.target_arch }}"
+          fi
+
+          publish_arch_args=""
+          case "$target_arch" in
+            x86_64)
+              publish_arch_args="-p:RuntimeIdentifier=maccatalyst-x64 -p:RuntimeIdentifiers=maccatalyst-x64"
+              ;;
+            arm64)
+              publish_arch_args="-p:RuntimeIdentifier=maccatalyst-arm64 -p:RuntimeIdentifiers=maccatalyst-arm64"
+              ;;
+            universal)
+              ;;
+            *)
+              echo "::error::Unsupported target_arch '$target_arch'"
+              exit 1
+              ;;
+          esac
+
+          echo "target_arch=$target_arch" >> "$GITHUB_OUTPUT"
+          echo "publish_arch_args=$publish_arch_args" >> "$GITHUB_OUTPUT"
+          echo "Building target_arch=$target_arch"
+
       - name: Publish PowerPlanneriOS (Mac Catalyst)
         # RuntimeIdentifiers (set in the csproj for maccatalyst) produces a universal binary (arm64 + x64).
-        run: >-
-          dotnet publish PowerPlanneriOS/PowerPlanneriOS.csproj
-          -f net10.0-maccatalyst
-          -c Release
-          --self-contained
-          -p:CreatePackage=true
-          -p:CodesignProvision="${{ vars.MAC_APP_PROVISIONING_PROFILE_NAME }}"
-          -p:CodesignKey="Apple Distribution: BareBones Dev%2c LLC (A9B367L69G)"
-          ${{ vars.ADDITIONAL_BUILD_ARGUMENTS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARCH_ARGS="${{ steps.maccatalyst_target.outputs.publish_arch_args }}"
+
+          dotnet publish PowerPlanneriOS/PowerPlanneriOS.csproj \
+            -f net10.0-maccatalyst \
+            -c Release \
+            --self-contained \
+            -p:CreatePackage=true \
+            -p:CodesignProvision="${{ vars.MAC_APP_PROVISIONING_PROFILE_NAME }}" \
+            -p:CodesignKey="Apple Distribution: BareBones Dev%2c LLC (A9B367L69G)" \
+            $ARCH_ARGS \
+            ${{ vars.ADDITIONAL_BUILD_ARGUMENTS }}
 
       - name: Fix widget signature and create signed PKG
         # dotnet re-signs embedded extensions without application-identifier, and the universal

--- a/PowerPlanneriOS/Entitlements-Mac.plist
+++ b/PowerPlanneriOS/Entitlements-Mac.plist
@@ -8,6 +8,12 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<!-- Required for the Mono interpreter to generate trampolines on x86_64 (Intel) Mac Catalyst.
+	     arm64 uses the MAP_JIT mechanism covered by allow-jit, but x86_64 marks executable
+	     memory without MAP_JIT, which requires this entitlement; without it the x64 build
+	     crashes on launch (null jump while UIKit instantiates the AppDelegate). -->
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/PowerPlanneriOS/Entitlements-Mac.plist
+++ b/PowerPlanneriOS/Entitlements-Mac.plist
@@ -6,6 +6,8 @@
 	<string>A9B367L69G.com.barebonesdev.powerplanner</string>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/PowerPlanneriOS/PowerPlanneriOS.csproj
+++ b/PowerPlanneriOS/PowerPlanneriOS.csproj
@@ -21,10 +21,12 @@
     <CodeSignEntitlements>Entitlements-Mac.plist</CodeSignEntitlements>
     <MTouchLink>SdkOnly</MTouchLink>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+  <!-- The interpreter is required on iOS and ARM64 Mac Catalyst (dynamic code generation is disallowed there),
+       but x64 Mac Catalyst supports JIT and crashes on launch if the interpreter is enabled, so exclude that RID. -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug' And '$(RuntimeIdentifier)' != 'maccatalyst-x64'">
     <UseInterpreter>true</UseInterpreter>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' And '$(RuntimeIdentifier)' != 'maccatalyst-x64'">
     <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' And '$(RuntimeIdentifier)' == ''">

--- a/PowerPlanneriOS/PowerPlanneriOS.csproj
+++ b/PowerPlanneriOS/PowerPlanneriOS.csproj
@@ -30,6 +30,15 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
     <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
   </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+    <WidgetXcodeArchArgs>ARCHS='%24(ARCHS_STANDARD)' ONLY_ACTIVE_ARCH=NO</WidgetXcodeArchArgs>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' And '$(RuntimeIdentifier)' == 'maccatalyst-x64'">
+    <WidgetXcodeArchArgs>ARCHS='x86_64' ONLY_ACTIVE_ARCH=NO</WidgetXcodeArchArgs>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' And '$(RuntimeIdentifier)' == 'maccatalyst-arm64'">
+    <WidgetXcodeArchArgs>ARCHS='arm64' ONLY_ACTIVE_ARCH=NO</WidgetXcodeArchArgs>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <DefineConstants>BUILD_OS_WINDOWS</DefineConstants>
   </PropertyGroup>
@@ -144,12 +153,12 @@
 
   <!--For Mac Catalyst widget, in debug mode don't sign-->
   <Target Name="BuildDebugXcodeProjectMac" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Debug' And '$(OS)' != 'Windows_NT' And '$(TargetPlatformIdentifier)' == 'maccatalyst'">
-    <Exec Command="xcodebuild -project $(MSBuildProjectDirectory)/../PowerPlanneriOSWidget/NativeApp.xcodeproj -scheme NativeApp -destination 'platform=macOS,variant=Mac Catalyst' -configuration $(Configuration) -derivedDataPath $(MSBuildProjectDirectory)/../PowerPlanneriOSWidget/DerivedData/NativeApp CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO" />
+    <Exec Command="xcodebuild -project $(MSBuildProjectDirectory)/../PowerPlanneriOSWidget/NativeApp.xcodeproj -scheme NativeApp -destination 'generic/platform=macOS,variant=Mac Catalyst' -configuration $(Configuration) -derivedDataPath $(MSBuildProjectDirectory)/../PowerPlanneriOSWidget/DerivedData/NativeApp CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO $(WidgetXcodeArchArgs)" />
   </Target>
 
   <!--For Mac Catalyst widget, in release mode it should sign-->
   <Target Name="BuildReleaseXcodeProjectMac" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Release' And '$(TargetPlatformIdentifier)' == 'maccatalyst'">
-    <Exec Command="xcodebuild -project $(MSBuildProjectDirectory)/../PowerPlanneriOSWidget/NativeApp.xcodeproj -scheme NativeApp -destination 'platform=macOS,variant=Mac Catalyst' -configuration $(Configuration) -derivedDataPath $(MSBuildProjectDirectory)/../PowerPlanneriOSWidget/DerivedData/NativeApp CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=&quot;Apple Distribution&quot; ARCHS='%24(ARCHS_STANDARD)' ONLY_ACTIVE_ARCH=NO" />
+    <Exec Command="xcodebuild -project $(MSBuildProjectDirectory)/../PowerPlanneriOSWidget/NativeApp.xcodeproj -scheme NativeApp -destination 'generic/platform=macOS,variant=Mac Catalyst' -configuration $(Configuration) -derivedDataPath $(MSBuildProjectDirectory)/../PowerPlanneriOSWidget/DerivedData/NativeApp CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=&quot;Apple Distribution&quot; $(WidgetXcodeArchArgs)" />
   </Target>
   
   <!--For iOS widget-->

--- a/PowerPlanneriOS/PowerPlanneriOS.csproj
+++ b/PowerPlanneriOS/PowerPlanneriOS.csproj
@@ -20,21 +20,15 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <CodeSignEntitlements>Entitlements-Mac.plist</CodeSignEntitlements>
     <MTouchLink>SdkOnly</MTouchLink>
-    <!-- The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
-         When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifer>.
-         The App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
-         either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
-    <!-- ex. <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <UseInterpreter>true</UseInterpreter>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-    <UseInterpreter>false</UseInterpreter>
-    <DebuggerSupport>false</DebuggerSupport>
+    <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <DefineConstants>BUILD_OS_WINDOWS</DefineConstants>

--- a/PowerPlanneriOS/PowerPlanneriOS.csproj
+++ b/PowerPlanneriOS/PowerPlanneriOS.csproj
@@ -21,12 +21,10 @@
     <CodeSignEntitlements>Entitlements-Mac.plist</CodeSignEntitlements>
     <MTouchLink>SdkOnly</MTouchLink>
   </PropertyGroup>
-  <!-- The interpreter is required on iOS and ARM64 Mac Catalyst (dynamic code generation is disallowed there),
-       but x64 Mac Catalyst supports JIT and crashes on launch if the interpreter is enabled, so exclude that RID. -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug' And '$(RuntimeIdentifier)' != 'maccatalyst-x64'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <UseInterpreter>true</UseInterpreter>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release' And '$(RuntimeIdentifier)' != 'maccatalyst-x64'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' And '$(RuntimeIdentifier)' == ''">

--- a/PowerPlanneriOS/PowerPlanneriOS.csproj
+++ b/PowerPlanneriOS/PowerPlanneriOS.csproj
@@ -29,8 +29,12 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <UseInterpreter>true</UseInterpreter>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
     <MtouchInterpreter>-all</MtouchInterpreter>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+    <UseInterpreter>false</UseInterpreter>
+    <DebuggerSupport>false</DebuggerSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <DefineConstants>BUILD_OS_WINDOWS</DefineConstants>

--- a/PowerPlanneriOS/PowerPlanneriOS.csproj
+++ b/PowerPlanneriOS/PowerPlanneriOS.csproj
@@ -27,7 +27,7 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' And '$(RuntimeIdentifier)' == ''">
     <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">


### PR DESCRIPTION
Crash is in debugger trampoline setup on x64 Mac.
ARM works, which matches a platform-specific runtime path issue. The project previously applied Release interpreter settings globally, including Mac Catalyst, which can trigger different Mono startup behavior.