### PR TITLE
Fix Droid and iOS Class Notification Time Formatting

### DIFF
--- a/PowerPlannerAndroid/Extensions/DroidClassRemindersExtension.cs
+++ b/PowerPlannerAndroid/Extensions/DroidClassRemindersExtension.cs
@@ -11,6 +11,7 @@ using Android.Service.Notification;
 using Android.Views;
 using Android.Widget;
 using AndroidX.Core.App;
+using InterfacesDroid.Helpers;
 using PowerPlannerAndroid.Helpers;
 using PowerPlannerAndroid.Receivers;
 using PowerPlannerAppDataLibrary;
@@ -177,7 +178,7 @@ namespace PowerPlannerAndroid.Extensions
             builder.SetShowWhen(false);
             builder.SetContentTitle(currSchedule.Class.Name);
 
-            string summaryText = string.Format(PowerPlannerResources.GetString("String_TimeToTime"), currSchedule.StartTimeInLocalTime(date).ToString("t"), currSchedule.EndTimeInLocalTime(date).ToString("t"));
+            string summaryText = string.Format(PowerPlannerResources.GetString("String_TimeToTime"), DateHelper.ToShortTimeString(currSchedule.StartTimeInLocalTime(date)), DateHelper.ToShortTimeString(currSchedule.EndTimeInLocalTime(date)));
             if (!string.IsNullOrWhiteSpace(currSchedule.Room))
             {
                 builder.SetContentText(summaryText + " - " + currSchedule.Room);

--- a/PowerPlannerAppDataLibrary/App/AppUpdatedHandler.cs
+++ b/PowerPlannerAppDataLibrary/App/AppUpdatedHandler.cs
@@ -106,6 +106,11 @@ namespace PowerPlannerAppDataLibrary.App
         {
             string changedText = "";
 
+            if (v <= new Version(2608, 10, 0, 0) && (VxPlatform.Current == Platform.iOS || VxPlatform.Current == Platform.Android))
+            {
+                changedText += "\n - Fixed time formatting (12 vs 24hr) on class reminders.";
+            }
+
             if (v <= new Version(2607, 17, 0, 0))
             {
                 changedText += "\n - Significantly faster launch speed!";

--- a/PowerPlanneriOS/Extensions/IOSClassRemindersExtension.cs
+++ b/PowerPlanneriOS/Extensions/IOSClassRemindersExtension.cs
@@ -13,6 +13,7 @@ using PowerPlannerAppDataLibrary.ViewItemsGroups;
 using PowerPlannerAppDataLibrary.ViewLists;
 using ToolsPortable;
 using UserNotifications;
+using Vx.Extensions;
 
 namespace PowerPlanneriOS.Extensions
 {
@@ -121,8 +122,8 @@ namespace PowerPlanneriOS.Extensions
                 // Format time range
                 string timeRange = string.Format(
                     PowerPlannerResources.GetString("String_TimeToTime"),
-                    schedule.StartTimeInLocalTime(date).ToString("t"),
-                    schedule.EndTimeInLocalTime(date).ToString("t"));
+                    DateTimeFormatterExtension.Current.FormatAsShortTime(schedule.StartTimeInLocalTime(date)),
+                    DateTimeFormatterExtension.Current.FormatAsShortTime(schedule.EndTimeInLocalTime(date)));
 
                 // Add room if available
                 if (!string.IsNullOrWhiteSpace(schedule.Room))


### PR DESCRIPTION
Droid and iOS weren't using the platform-specific time formatting for the time strings on the class notifications.